### PR TITLE
Update New-InsightObjectAttribute.ps1

### DIFF
--- a/PSInsight/Public/Objects/New-InsightObjectAttribute.ps1
+++ b/PSInsight/Public/Objects/New-InsightObjectAttribute.ps1
@@ -37,23 +37,23 @@ $array = @($1,$2) # For use with New-InsightObject
 
         [ValidateNotNullOrEmpty()]
         [Parameter(Mandatory = $true,valuefrompipelinebypropertyname = $true)]
-        [String]$objectAttributeValues
+        [String[]]$objectAttributeValues
     )
     
     begin {
-       
+        $values = New-Object System.Collections.ArrayList 
     }
     
     process {
-
+        $objectAttributeValues | ForEach-Object {
+            $values.Add(@{'value' = $_}) | Out-Null
+        }        
         $Attribute = @{
             'objectTypeAttributeId' = $objectTypeAttributeId
-            'objectAttributeValues'   = @(@{
-                'value' = $objectAttributeValues
-                })
+            'objectAttributeValues'   = @($values)
             }
 
-    }
+}
     
     end {
                 


### PR DESCRIPTION
Changed function to accept an array and edited hashtable creation to allow multiple values for fields with cardinality > 1.
See Output Json Example 2 --> https://documentation.mindville.com/display/INSCLOUD/REST+API+-+Update+object 

Example Call: $attributeArray += New-InsightObjectAttribute -objectTypeAttributeId 393 -objectAttributeValues 'ITSM-1','ITSM-2'